### PR TITLE
アカウント作成とログインの認証をemailではなく、nameで行う

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,16 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   validates :name, presence: true, length: { maximum: 20 }, format: { with: /^[0-9a-zA-Z]+$/, multiline: true, message: I18n.t('errors.user.name') }
+
+  def email_required?
+    false
+  end
+
+  def email_changed?
+    false
+  end
+
+  def will_save_change_to_email?
+    false
+  end
 end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -3,10 +3,6 @@
 = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
   = f.error_notification
   .form-inputs
-    = f.input :email, required: true, autofocus: true
-    - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-      %p
-        Currently waiting confirmation for: #{resource.unconfirmed_email}
     = f.input :name
     = f.input :password
     = f.input :password_confirmation

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,0 +1,18 @@
+%h2 Sign up
+= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+  = f.error_notification
+  .form-inputs
+    = f.input :name,
+      required: true,
+      autofocus: true,
+      input_html: { autocomplete: "name" }
+    = f.input :password,
+      required: true,
+      hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
+      input_html: { autocomplete: "new-password" }
+    = f.input :password_confirmation,
+      required: true,
+      input_html: { autocomplete: "new-password" }
+  .form-actions
+    = f.button :submit, "Sign up"
+= render "devise/shared/links"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,0 +1,14 @@
+%h2 Log in
+= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
+  .form-inputs
+    = f.input :name,
+      required: false,
+      autofocus: true,
+      input_html: { autocomplete: "email" }
+    = f.input :password,
+      required: false,
+      input_html: { autocomplete: "current-password" }
+    = f.input :remember_me, as: :boolean if devise_mapping.rememberable?
+  .form-actions
+    = f.button :submit, "Log in"
+= render "devise/shared/links"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:name]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the
@@ -58,12 +58,12 @@ Devise.setup do |config|
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:email]
+  config.case_insensitive_keys = []
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:email]
+  config.strip_whitespace_keys = []
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the

--- a/db/migrate/20240531091325_remove_email_on_users.rb
+++ b/db/migrate/20240531091325_remove_email_on_users.rb
@@ -1,0 +1,5 @@
+class RemoveEmailOnUsers < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :users, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_31_053949) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_31_091325) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
-    t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
@@ -23,7 +22,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_31_053949) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name", limit: 20, default: "", null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    email { 'hatt@example.com' }
+    name { 'hakjae' }
     password { '1234512345' }
     password_confirmation { '1234512345' }
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -20,10 +20,12 @@ RSpec.describe 'Users', type: :system do
       visit root_path
       expect(page).not_to have_button 'ログアウト'
       click_on 'サインアップ'
-      fill_in '名前', with: 'hakjae'
-      fill_in 'パスワード', with: '1234512345'
+      fill_in '名前', with: 'taji'
+      fill_in 'パスワード', match: :first, with: '1234512345'
+      fill_in 'パスワード（確認用）', with: '1234512345'
+      click_on 'Sign up'
       expect(page).to have_current_path root_path, ignore_query: true
-      expect(page).to have_content 'アカウント作成しました'
+      expect(page).to have_content 'アカウント登録が完了しました。'
     end
   end
 

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,26 +1,33 @@
 require 'rails_helper'
 
 RSpec.describe 'Users', type: :system do
+  let!(:user) { create(:user, name: 'hakjae', password: '1234512345', password_confirmation: '1234512345') }
+
   context '未ログイン時' do
-    it 'ログインを押してログインフォームが開くこと' do
+    it 'ログインを押してログインフォームからログインできる' do
       visit root_path
       expect(page).not_to have_link '認証情報編集'
       expect(page).not_to have_button 'ログアウト'
       click_on 'ログイン'
-      expect(page).to have_current_path new_user_session_path, ignore_query: true
+      fill_in '名前', with: 'hakjae'
+      fill_in 'パスワード', with: '1234512345'
+      click_on 'ログイン'
+      expect(page).to have_current_path root_path, ignore_query: true
+      expect(page).to have_content 'ログインしました'
     end
 
     it 'サインアップを押してサインアップフォームが開くこと' do
       visit root_path
       expect(page).not_to have_button 'ログアウト'
       click_on 'サインアップ'
-      expect(page).to have_current_path new_user_registration_path, ignore_query: true
+      fill_in '名前', with: 'hakjae'
+      fill_in 'パスワード', with: '1234512345'
+      expect(page).to have_current_path root_path, ignore_query: true
+      expect(page).to have_content 'アカウント作成しました'
     end
   end
 
   context 'ログイン時' do
-    let!(:user) { create(:user, name: 'hakjae', password: '1234512345', password_confirmation: '1234512345') }
-
     before do
       sign_in user
     end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'Users', type: :system do
       click_on 'ログイン'
       fill_in '名前', with: 'hakjae'
       fill_in 'パスワード', with: '1234512345'
-      click_on 'ログイン'
+      click_on 'Log in'
       expect(page).to have_current_path root_path, ignore_query: true
       expect(page).to have_content 'ログインしました'
     end


### PR DESCRIPTION
- [x] 名前とパスワードを使って、サインインとサインアップができるように 15m
  - [x] emailカラムを削除 3m
  - [x] emailではなくnameを使って認証できるように 5m
- [x] アカウント作成画面にemailではなく、名前フィールドを表示する 3m
- [x] サインイン画面にemailではなく、名前フィールドを表示する 3m